### PR TITLE
Store AWS credentials in a secret instead of deployment env

### DIFF
--- a/aws-ssm/templates/deployment.yaml
+++ b/aws-ssm/templates/deployment.yaml
@@ -42,18 +42,12 @@ spec:
             httpGet:
               path: /healthz
               port: {{ .Values.metrics_port }}
+          envFrom:
+              - secretRef:
+                  name: aws-ssm-credentials 
           env:
-            - name: AWS_REGION
-              value: {{ .Values.aws.region }}
-              
             - name: METRICS_URL
               value: 0.0.0.0:{{ .Values.metrics_port }}
-
-            - name: AWS_ACCESS_KEY
-              value: "{{ .Values.aws.access_key }}"
-
-            - name: AWS_SECRET_KEY
-              value: "{{ .Values.aws.secret_key }}"
           {{ if ne .Values.host_ssl_dir "" -}}
           volumeMounts:
             - mountPath: /etc/ssl/certs

--- a/aws-ssm/templates/secret.yaml
+++ b/aws-ssm/templates/secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-ssm-credentials
+type: Opaque
+stringData:
+        AWS_REGION:  "{{ .Values.aws.region }}"
+        AWS_ACCESS_KEY: "{{ .Values.aws.access_key }}"
+        AWS_SECRET_KEY: "{{ .Values.aws.secret_key }}"


### PR DESCRIPTION
This avoids the credentials to be displayed in clear text when inspecting the deployment of aws-ssm.