### PR TITLE
Use the default credential provider chain instead of only from env.

### DIFF
--- a/pkg/provider/aws.go
+++ b/pkg/provider/aws.go
@@ -19,7 +19,6 @@ import (
 	"path"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/cmattoon/aws-ssm/pkg/config"
@@ -33,8 +32,7 @@ type AWSProvider struct {
 
 func NewAWSProvider(cfg *config.Config) (Provider, error) {
 	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String(cfg.AWSRegion),
-		Credentials: credentials.NewEnvCredentials(),
+		Region: aws.String(cfg.AWSRegion),
 	})
 
 	if err != nil {


### PR DESCRIPTION
We are using https://github.com/uswitch/kiam to associate IAM roles to Pods.