### PR TITLE
Move apiVersion of Deployment to apps/v1 as extensions/v1beta1 is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,20 +40,21 @@ The following chart values may be set. Only the required variables (AWS credenti
 defaults should work as-is.
 
 
-| Req'd | Value          | Default          | Example                     | Description                                                      |
-|-------|----------------|------------------|-----------------------------|------------------------------------------------------------------|
-| YES   | aws.region     | ""               | us-west-2                   | The AWS region in which the Pod is deployed                      |
-| NO    | aws.access_key | ""               |                             | REQUIRED when no other auth method available (e.g., IAM role)    |
-| NO    | aws.secret_key | ""               |                             | REQUIRED when no other auth method available (e.g., IAM role)    |
-| NO    | kubeconfig64   | ""               | <string>                    | The output of `$(cat $KUBE_CONFIG \| base64)`. Stored as a Secret|
-| NO    | metrics_port   | 9999             | <int>                       | Serve metrics/healthchecks on this port                          |
-| NO    | image.name     | cmattoon/aws-ssm | <docker-repo>/<image-name>  | The Docker image to use for the Pod container                    |
-| NO    | image.tag      | latest           | <docker-tag>                | The Docker tag for the image                                     |
-| NO    | resources      | {}               | <dict>                      | Kubernetes Resource Requests/Limits                              |
-| NO    | rbac.enabled   | true             | <bool>                      | Whether or not to add Kubernetes RBAC stuff                      |
-| NO    | ssl.mount_host | false            | <bool>                      | Mounts {ssl.host_path} -> {ssl.mount_path} as hostVolume         |
-| NO    | ssl.host_path  | /etc/ssl/certs   | <path>                      | The SSL certs dir on the host                                    |
-| NO    | ssl.mount_path | /etc/ssl/certs   | <path>                      | The SSL certs dir in the container (dev)                         |
+| Req'd | Value             | Default          | Example                     | Description                                                      |
+|-------|-------------------|------------------|-----------------------------|------------------------------------------------------------------|
+| YES   | aws.region        | ""               | us-west-2                   | The AWS region in which the Pod is deployed                      |
+| NO    | aws.access_key    | ""               |                             | REQUIRED when no other auth method available (e.g., IAM role)    |
+| NO    | aws.secret_key    | ""               |                             | REQUIRED when no other auth method available (e.g., IAM role)    |
+| NO    | aws.session_token | ""               |                             | OPTIONAL when using temporary access/secret keys (e.g. in CI)    |
+| NO    | kubeconfig64      | ""               | <string>                    | The output of `$(cat $KUBE_CONFIG \| base64)`. Stored as a Secret|
+| NO    | metrics_port      | 9999             | <int>                       | Serve metrics/healthchecks on this port                          |
+| NO    | image.name        | cmattoon/aws-ssm | <docker-repo>/<image-name>  | The Docker image to use for the Pod container                    |
+| NO    | image.tag         | latest           | <docker-tag>                | The Docker tag for the image                                     |
+| NO    | resources         | {}               | <dict>                      | Kubernetes Resource Requests/Limits                              |
+| NO    | rbac.enabled      | true             | <bool>                      | Whether or not to add Kubernetes RBAC stuff                      |
+| NO    | ssl.mount_host    | false            | <bool>                      | Mounts {ssl.host_path} -> {ssl.mount_path} as hostVolume         |
+| NO    | ssl.host_path     | /etc/ssl/certs   | <path>                      | The SSL certs dir on the host                                    |
+| NO    | ssl.mount_path    | /etc/ssl/certs   | <path>                      | The SSL certs dir in the container (dev)                         |
 
 
 Configuration

--- a/aws-ssm/Chart.yaml
+++ b/aws-ssm/Chart.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 description: Dynamic secret management for Kubernetes
 name: aws-ssm
-version: 0.2.7
+version: 0.2.8
 appVersion: 0.2.7
 keywords:
   - aws

--- a/aws-ssm/Chart.yaml
+++ b/aws-ssm/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v1
 description: Dynamic secret management for Kubernetes
 name: aws-ssm
-version: 0.1.7
-appVersion: 0.1.7
+version: 0.2.7
+appVersion: 0.2.7
 keywords:
   - aws
   - secret

--- a/aws-ssm/templates/deployment.yaml
+++ b/aws-ssm/templates/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "ssm.fullname" . }}
@@ -15,6 +15,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "ssm.name" . }}
+      release: {{ .Release.Name }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/aws-ssm/templates/secret.yaml
+++ b/aws-ssm/templates/secret.yaml
@@ -14,4 +14,7 @@ type: Opaque
 data:
   AWS_ACCESS_KEY: "{{ .Values.aws.access_key | b64enc }}"
   AWS_SECRET_KEY: "{{ .Values.aws.secret_key | b64enc }}"
+  {{ if ne .Values.aws.session_token "" -}}
+  AWS_SESSION_TOKEN: "{{ .Values.aws.session_token | b64enc }}"
+  {{ end -}}
 {{ end -}}

--- a/aws-ssm/values.yaml
+++ b/aws-ssm/values.yaml
@@ -6,6 +6,8 @@ aws:
   access_key: ""
   # AWS_SECRET_ACCESS_KEY
   secret_key: ""
+  # AWS_SESSION_TOKEN
+  session_token: ""
 
 # Docker Image to use
 image:


### PR DESCRIPTION
With k8s 1.21 the deployment apiVersion supported is apps/v1 and the
extensions/v1beta1 is deprecated, thus the installation of the chart
fails with:

Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Deployment" in version "extensions/v1beta1"

This update fixes it and the chart can be installed.

Tested on cluster:

❯ kubectl get no -o wide
NAME                 STATUS   ROLES                  AGE   VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE       KERNEL-VERSION     CONTAINER-RUNTIME
kind-control-plane   Ready    control-plane,master   52d   v1.21.1   172.18.0.2    <none>        Ubuntu 21.04   5.10.25-linuxkit   containerd://1.5.2